### PR TITLE
initial phpunit test, test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: php
+
+php:
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+
+matrix:
+  fast_finish: true
+
+before_script:
+  - composer install --no-interaction
+
+script:
+  - ./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,10 @@
   "keywords" : ["argument", "option", "getopt", "parser", "parsing", "command line", "shell", "script"],
   "license": "MIT",
   "require": {
-    "php": "~5.6|~7.0"
+    "php": ">=5.6"
   },
   "require-dev": {
-    "phpunit/phpunit": "~5.5.0"
+    "phpunit/phpunit": "^5.5|^6.5"
   },
   "authors": [
     {
@@ -20,6 +20,11 @@
   "autoload": {
     "psr-4": {
       "Fostam\\GetOpts\\": "src"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Fostam\\GetOpts\\Tests\\": "tests"
     }
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+
+    <testsuites>
+        <testsuite name="getopts Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+
+</phpunit>

--- a/tests/Config/ArgumentTest.php
+++ b/tests/Config/ArgumentTest.php
@@ -6,10 +6,7 @@ use Fostam\GetOpts\Exception\ArgumentConfigException;
 use PHPUnit\Framework\TestCase;
 use Fostam\GetOpts\Config\Argument;
 
-/**
- * @covers Argument
- */
-final class ArgumentTest extends TestCase {
+class ArgumentTest extends TestCase {
     /** @var Argument */
     private $argument;
 

--- a/tests/Config/OptionTest.php
+++ b/tests/Config/OptionTest.php
@@ -6,10 +6,7 @@ use Fostam\GetOpts\Exception\OptionConfigException;
 use PHPUnit\Framework\TestCase;
 use Fostam\GetOpts\Config\Option;
 
-/**
- * @covers Option
- */
-final class OptionTest extends TestCase {
+class OptionTest extends TestCase {
     /** @var Option */
     private $option;
 

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -6,10 +6,7 @@ use Fostam\GetOpts\Exception\MissingArgumentsException;
 use Fostam\GetOpts\Handler;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers Handler
- */
-final class HandlerTest extends TestCase {
+class HandlerTest extends TestCase {
     public function testHandling() {
         $handler = new Handler();
         $handler->addOption('opt1')->short('a')->incrementable();

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -12,10 +12,7 @@ use Fostam\GetOpts\Exception\InvalidArgumentException;
 use Fostam\GetOpts\Config\Option;
 use Fostam\GetOpts\Parser;
 
-/**
- * @covers Parser
- */
-final class ParserTest extends TestCase {
+class ParserTest extends TestCase {
     // bool options
     public function testShortOptionBoolGiven() {
         $opt = new Option();
@@ -425,7 +422,7 @@ final class ParserTest extends TestCase {
 
     // options / arguments mixed
     /**
-     * @dataProvider testOptionsArgumentsMixedProvider
+     * @dataProvider optionsArgumentsMixedProvider
      * @param $args
      * @param $expectedOpts
      * @param $expectedArgs
@@ -452,7 +449,7 @@ final class ParserTest extends TestCase {
         $this->assertEquals($expectedArgs, $result[Parser::RESULT_ARGUMENTS]);
     }
 
-    public function testOptionsArgumentsMixedProvider() {
+    public function optionsArgumentsMixedProvider() {
         return [
             [ ['x'], ['a' => null, 'b' => null, 'c' => 'defval'], ['x' => 'x', 'y' => null] ],
             [ ['x', 'y'], ['a' => null, 'b' => null, 'c' => 'defval'], ['x' => 'x', 'y' => 'y'] ],


### PR DESCRIPTION
# Changed log 

- initial the Travis CI build. Please see the [Travis build log](https://travis-ci.org/peter279k/php-getopts/builds/365054540).
- set the correct PHPUnit setting.
- add the ```autoload-dev``` class-based test namespace in ```composer.json```.